### PR TITLE
Fixed small mathematical errors.

### DIFF
--- a/src/collide_fine.cpp
+++ b/src/collide_fine.cpp
@@ -684,7 +684,7 @@ unsigned CollisionDetector::boxAndHalfSpace(
             // distance and add the vertex location.
             contact->contactPoint = plane.direction;
             contact->contactPoint *= (vertexDistance-plane.offset);
-            contact->contactPoint = vertexPos;
+            contact->contactPoint += vertexPos;
             contact->contactNormal = plane.direction;
             contact->penetration = plane.offset - vertexDistance;
 

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -44,7 +44,7 @@ real cyclone::getSleepEpsilon()
 
 real Matrix4::getDeterminant() const
 {
-    return data[8]*data[5]*data[2]+
+    return -data[8]*data[5]*data[2]+
         data[4]*data[9]*data[2]+
         data[8]*data[1]*data[6]-
         data[0]*data[9]*data[6]-


### PR DESCRIPTION
The first issue in src/collide_fine.cpp was something I noticed from the book, where the contactPoint's value gets overwritten when it should just be displaced by the vertexPos vector.

The issue in Matrix4::getDeterminant() I noticed when I was trying to use the matrix inverse method for the first time. For a rotation matrix I had, the determinant was returning an incorrect value which I confirmed with my calculator and various online tools. I have derived the Matrix4 determinant method again below:

Original Matrix:
[[a, b, c, d]
[e, f, g, h]
[i, j , k, l]
[0, 0, 0, 1]]

Determinant:
+a \* det([[f, g, h], [j, k, l], [0, 0, 1]])
-b \* det([[e, g, h], [i, k, l], [0, 0, 1]])
+c \* det([[e, f, h], [i, j, l], [0, 0, 1]])
-d \* det([[e, f, g], [i, j, k], [0, 0, 0]])

Since the matrix d is multiplied by has all zeros for the last row, it has a determinant of 0. Since each of the remaining three matrices have two zeros in the bottom row, they each reduce to the 2x2 matrix made of the top left corner of each matrix. Therefore we have:

Determinant:
+a_(f_k - g_j) - b_(e_k - g_i) + c_(e_j - f*i)
= afk - agj - bek + bgi + cej - cfi

Substituting in a = data[0], b = data[1], and so on we get:
+data[0] \* data[5] \* data[10]
-data[0] \* data[6] \* data[9]
-data[1] \* data[4] \* data[10]
+data[1] \* data[6] \* data[8]
+data[2] \* data[4] \* data[9]
-data[2] \* data[5] \* data[8]

Which is equivalent to the old code (just in a different order):
return  data[8] \* data[5] \* data[2]+
          data[4] \* data[9] \* data[2]+
          data[8] \* data[1] \* data[6]-
          data[0] \* data[9] \* data[6]-
          data[4] \* data[1] \* data[10]+
          data[0] \* data[5] \* data[10];

With the exception of the first line needing to be negative.

If I messed up, I apologize for wasting your time. I've absolutely loved reading and implementing things from your book.
