### PR TITLE
Fixed deletion bug in BVH destructor.

### DIFF
--- a/include/cyclone/collide_coarse.h
+++ b/include/cyclone/collide_coarse.h
@@ -288,7 +288,7 @@ namespace cyclone {
         }
         if (children[1]) {
             children[1]->parent = NULL;
-            delete children[0];
+            delete children[1];
         }
     }
 


### PR DESCRIPTION
Hello,

I've fixed issue #8 on the branch named BVHDestructorFix in my fork. While this bug did not cause any crashes, it still causes memory leaks.

Thanks!
