### PR TITLE
VS2010 projects relative paths updated. 

### DIFF
--- a/build/vs2010/cyclone_vc10.vcxproj
+++ b/build/vs2010/cyclone_vc10.vcxproj
@@ -38,11 +38,11 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
-    <_ProjectFileVersion>10.0.40219.1</_ProjectFileVersion>
-    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">.\..\lib\</OutDir>
-    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">.\tmp\Debug\</IntDir>
-    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">.\..\lib\</OutDir>
-    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">.\tmp\Release\</IntDir>
+    <_ProjectFileVersion>10.0.40219.1</_ProjectFileVersion>	 
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\..\lib\win32\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\..\tmp\Debug\</IntDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\..\lib\win32\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\..\tmp\Release\</IntDir>
     <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">AllRules.ruleset</CodeAnalysisRuleSet>
     <CodeAnalysisRules Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
@@ -54,15 +54,15 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <PrecompiledHeader>
       </PrecompiledHeader>
-      <PrecompiledHeaderOutputFile>.\tmp\Debug/cyclone.pch</PrecompiledHeaderOutputFile>
-      <AssemblerListingLocation>.\tmp\Debug/</AssemblerListingLocation>
-      <ObjectFileName>.\tmp\Debug/</ObjectFileName>
+      <PrecompiledHeaderOutputFile>..\..\tmp\Debug/cyclone.pch</PrecompiledHeaderOutputFile>
+      <AssemblerListingLocation>..\..\tmp\Debug/</AssemblerListingLocation>
+      <ObjectFileName>..\..\tmp\Debug/</ObjectFileName>
       <ProgramDataBaseFileName>.\tmp\Debug/</ProgramDataBaseFileName>
       <BrowseInformation>true</BrowseInformation>
       <WarningLevel>Level3</WarningLevel>
@@ -75,23 +75,23 @@
       <Culture>0x0809</Culture>
     </ResourceCompile>
     <Lib>
-      <OutputFile>..\lib\$(TargetFileName)</OutputFile>
+      <OutputFile>..\..\lib\win32\$(TargetFileName)</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
     </Lib>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
       <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
-      <AdditionalIncludeDirectories>..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
-      <PrecompiledHeaderOutputFile>.\tmp\Release/cyclone.pch</PrecompiledHeaderOutputFile>
-      <AssemblerListingLocation>.\tmp\Release/</AssemblerListingLocation>
-      <ObjectFileName>.\tmp\Release/</ObjectFileName>
+      <PrecompiledHeaderOutputFile>..\..\tmp\Release/cyclone.pch</PrecompiledHeaderOutputFile>
+      <AssemblerListingLocation>..\..\tmp\Release/</AssemblerListingLocation>
+      <ObjectFileName>..\..\tmp\Release/</ObjectFileName>
       <ProgramDataBaseFileName>.\tmp\Release/</ProgramDataBaseFileName>
       <WarningLevel>Level3</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
@@ -102,43 +102,43 @@
       <Culture>0x0809</Culture>
     </ResourceCompile>
     <Lib>
-      <OutputFile>.\..\lib\cyclone.lib</OutputFile>
+      <OutputFile>..\..\lib\win32\cyclone.lib</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
     </Lib>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="..\src\body.cpp" />
-    <ClCompile Include="..\src\collide_coarse.cpp" />
-    <ClCompile Include="..\src\collide_fine.cpp" />
-    <ClCompile Include="..\src\contacts.cpp" />
-    <ClCompile Include="..\src\core.cpp" />
-    <ClCompile Include="..\src\fgen.cpp" />
-    <ClCompile Include="..\src\joints.cpp" />
-    <ClCompile Include="..\src\particle.cpp" />
-    <ClCompile Include="..\src\pcontacts.cpp" />
-    <ClCompile Include="..\src\pfgen.cpp" />
-    <ClCompile Include="..\src\plinks.cpp" />
-    <ClCompile Include="..\src\pworld.cpp" />
-    <ClCompile Include="..\src\random.cpp" />
-    <ClCompile Include="..\src\world.cpp" />
+    <ClCompile Include="..\..\src\body.cpp" />
+    <ClCompile Include="..\..\src\collide_coarse.cpp" />
+    <ClCompile Include="..\..\src\collide_fine.cpp" />
+    <ClCompile Include="..\..\src\contacts.cpp" />
+    <ClCompile Include="..\..\src\core.cpp" />
+    <ClCompile Include="..\..\src\fgen.cpp" />
+    <ClCompile Include="..\..\src\joints.cpp" />
+    <ClCompile Include="..\..\src\particle.cpp" />
+    <ClCompile Include="..\..\src\pcontacts.cpp" />
+    <ClCompile Include="..\..\src\pfgen.cpp" />
+    <ClCompile Include="..\..\src\plinks.cpp" />
+    <ClCompile Include="..\..\src\pworld.cpp" />
+    <ClCompile Include="..\..\src\random.cpp" />
+    <ClCompile Include="..\..\src\world.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\include\cyclone\body.h" />
-    <ClInclude Include="..\include\cyclone\collide_coarse.h" />
-    <ClInclude Include="..\include\cyclone\collide_fine.h" />
-    <ClInclude Include="..\include\cyclone\contacts.h" />
-    <ClInclude Include="..\include\cyclone\core.h" />
-    <ClInclude Include="..\include\cyclone\cyclone.h" />
-    <ClInclude Include="..\include\cyclone\fgen.h" />
-    <ClInclude Include="..\include\cyclone\joints.h" />
-    <ClInclude Include="..\include\cyclone\particle.h" />
-    <ClInclude Include="..\include\cyclone\pcontacts.h" />
-    <ClInclude Include="..\include\cyclone\pfgen.h" />
-    <ClInclude Include="..\include\cyclone\plinks.h" />
-    <ClInclude Include="..\include\cyclone\precision.h" />
-    <ClInclude Include="..\include\cyclone\pworld.h" />
-    <ClInclude Include="..\include\cyclone\random.h" />
-    <ClInclude Include="..\include\cyclone\world.h" />
+    <ClInclude Include="..\..\include\cyclone\body.h" />
+    <ClInclude Include="..\..\include\cyclone\collide_coarse.h" />
+    <ClInclude Include="..\..\include\cyclone\collide_fine.h" />
+    <ClInclude Include="..\..\include\cyclone\contacts.h" />
+    <ClInclude Include="..\..\include\cyclone\core.h" />
+    <ClInclude Include="..\..\include\cyclone\cyclone.h" />
+    <ClInclude Include="..\..\include\cyclone\fgen.h" />
+    <ClInclude Include="..\..\include\cyclone\joints.h" />
+    <ClInclude Include="..\..\include\cyclone\particle.h" />
+    <ClInclude Include="..\..\include\cyclone\pcontacts.h" />
+    <ClInclude Include="..\..\include\cyclone\pfgen.h" />
+    <ClInclude Include="..\..\include\cyclone\plinks.h" />
+    <ClInclude Include="..\..\include\cyclone\precision.h" />
+    <ClInclude Include="..\..\include\cyclone\pworld.h" />
+    <ClInclude Include="..\..\include\cyclone\random.h" />
+    <ClInclude Include="..\..\include\cyclone\world.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/build/vs2010/cyclone_vc10.vcxproj.filters
+++ b/build/vs2010/cyclone_vc10.vcxproj.filters
@@ -15,96 +15,96 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\src\body.cpp">
+    <ClCompile Include="..\..\src\body.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\collide_coarse.cpp">
+    <ClCompile Include="..\..\src\collide_coarse.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\collide_fine.cpp">
+    <ClCompile Include="..\..\src\collide_fine.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\contacts.cpp">
+    <ClCompile Include="..\..\src\contacts.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\core.cpp">
+    <ClCompile Include="..\..\src\core.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\fgen.cpp">
+    <ClCompile Include="..\..\src\fgen.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\joints.cpp">
+    <ClCompile Include="..\..\src\joints.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\particle.cpp">
+    <ClCompile Include="..\..\src\particle.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\pcontacts.cpp">
+    <ClCompile Include="..\..\src\pcontacts.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\pfgen.cpp">
+    <ClCompile Include="..\..\src\pfgen.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\plinks.cpp">
+    <ClCompile Include="..\..\src\plinks.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\pworld.cpp">
+    <ClCompile Include="..\..\src\pworld.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\random.cpp">
+    <ClCompile Include="..\..\src\random.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\world.cpp">
+    <ClCompile Include="..\..\src\world.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\include\cyclone\body.h">
+    <ClInclude Include="..\..\include\cyclone\body.h">
       <Filter>Header Files\cyclone</Filter>
     </ClInclude>
-    <ClInclude Include="..\include\cyclone\collide_coarse.h">
+    <ClInclude Include="..\..\include\cyclone\collide_coarse.h">
       <Filter>Header Files\cyclone</Filter>
     </ClInclude>
-    <ClInclude Include="..\include\cyclone\collide_fine.h">
+    <ClInclude Include="..\..\include\cyclone\collide_fine.h">
       <Filter>Header Files\cyclone</Filter>
     </ClInclude>
-    <ClInclude Include="..\include\cyclone\contacts.h">
+    <ClInclude Include="..\..\include\cyclone\contacts.h">
       <Filter>Header Files\cyclone</Filter>
     </ClInclude>
-    <ClInclude Include="..\include\cyclone\core.h">
+    <ClInclude Include="..\..\include\cyclone\core.h">
       <Filter>Header Files\cyclone</Filter>
     </ClInclude>
-    <ClInclude Include="..\include\cyclone\cyclone.h">
+    <ClInclude Include="..\..\include\cyclone\cyclone.h">
       <Filter>Header Files\cyclone</Filter>
     </ClInclude>
-    <ClInclude Include="..\include\cyclone\fgen.h">
+    <ClInclude Include="..\..\include\cyclone\fgen.h">
       <Filter>Header Files\cyclone</Filter>
     </ClInclude>
-    <ClInclude Include="..\include\cyclone\joints.h">
+    <ClInclude Include="..\..\include\cyclone\joints.h">
       <Filter>Header Files\cyclone</Filter>
     </ClInclude>
-    <ClInclude Include="..\include\cyclone\particle.h">
+    <ClInclude Include="..\..\include\cyclone\particle.h">
       <Filter>Header Files\cyclone</Filter>
     </ClInclude>
-    <ClInclude Include="..\include\cyclone\pcontacts.h">
+    <ClInclude Include="..\..\include\cyclone\pcontacts.h">
       <Filter>Header Files\cyclone</Filter>
     </ClInclude>
-    <ClInclude Include="..\include\cyclone\pfgen.h">
+    <ClInclude Include="..\..\include\cyclone\pfgen.h">
       <Filter>Header Files\cyclone</Filter>
     </ClInclude>
-    <ClInclude Include="..\include\cyclone\plinks.h">
+    <ClInclude Include="..\..\include\cyclone\plinks.h">
       <Filter>Header Files\cyclone</Filter>
     </ClInclude>
-    <ClInclude Include="..\include\cyclone\precision.h">
+    <ClInclude Include="..\..\include\cyclone\precision.h">
       <Filter>Header Files\cyclone</Filter>
     </ClInclude>
-    <ClInclude Include="..\include\cyclone\pworld.h">
+    <ClInclude Include="..\..\include\cyclone\pworld.h">
       <Filter>Header Files\cyclone</Filter>
     </ClInclude>
-    <ClInclude Include="..\include\cyclone\random.h">
+    <ClInclude Include="..\..\include\cyclone\random.h">
       <Filter>Header Files\cyclone</Filter>
     </ClInclude>
-    <ClInclude Include="..\include\cyclone\world.h">
+    <ClInclude Include="..\..\include\cyclone\world.h">
       <Filter>Header Files\cyclone</Filter>
     </ClInclude>
   </ItemGroup>

--- a/build/vs2010/demo_ballistic_vc10.vcxproj
+++ b/build/vs2010/demo_ballistic_vc10.vcxproj
@@ -38,11 +38,11 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.40219.1</_ProjectFileVersion>
-    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\bin\</OutDir>
-    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\tmp\ballistic\Debug\</IntDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\..\bin\win32\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\..\tmp\ballistic\Debug\</IntDir>
     <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</LinkIncremental>
-    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\bin\</OutDir>
-    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\tmp\ballistic\</IntDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\..\bin\win32\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\..\tmp\ballistic\</IntDir>
     <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</LinkIncremental>
     <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">AllRules.ruleset</CodeAnalysisRuleSet>
     <CodeAnalysisRules Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
@@ -56,7 +56,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -69,16 +69,16 @@
     <Link>
       <AdditionalDependencies>cyclone_d.lib;opengl32.lib;glu32.lib;glut32.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)$(TargetFileName)</OutputFile>
-      <AdditionalLibraryDirectories>../lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>../../lib/win32;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <ProgramDatabaseFile>..\tmp\ballistic\Debug/ballistic.pdb</ProgramDatabaseFile>
+      <ProgramDatabaseFile>..\..\tmp\ballistic\Debug/ballistic.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <AdditionalIncludeDirectories>..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <PrecompiledHeader>
@@ -89,7 +89,7 @@
     <Link>
       <AdditionalDependencies>cyclone.lib;opengl32.lib;glu32.lib;glut32.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)$(TargetFileName)</OutputFile>
-      <AdditionalLibraryDirectories>../lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>../../lib/win32;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
@@ -98,17 +98,17 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="..\src\demos\ballistic\ballistic.cpp" />
-    <ClCompile Include="..\src\demos\app.cpp" />
-    <ClCompile Include="..\src\demos\main.cpp">
+    <ClCompile Include="..\..\src\demos\ballistic\ballistic.cpp" />
+    <ClCompile Include="..\..\src\demos\app.cpp" />
+    <ClCompile Include="..\..\src\demos\main.cpp">
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)%(Filename)1.obj</ObjectFileName>
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)%(Filename)1.obj</ObjectFileName>
     </ClCompile>
-    <ClCompile Include="..\src\demos\timing.cpp" />
+    <ClCompile Include="..\..\src\demos\timing.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\src\demos\app.h" />
-    <ClInclude Include="..\src\demos\timing.h" />
+    <ClInclude Include="..\..\src\demos\app.h" />
+    <ClInclude Include="..\..\src\demos\timing.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/build/vs2010/demo_ballistic_vc10.vcxproj.filters
+++ b/build/vs2010/demo_ballistic_vc10.vcxproj.filters
@@ -18,24 +18,24 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\src\demos\ballistic\ballistic.cpp">
+    <ClCompile Include="..\..\src\demos\ballistic\ballistic.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\demos\app.cpp">
+    <ClCompile Include="..\..\src\demos\app.cpp">
       <Filter>Common Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\demos\main.cpp">
+    <ClCompile Include="..\..\src\demos\main.cpp">
       <Filter>Common Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\demos\timing.cpp">
+    <ClCompile Include="..\..\src\demos\timing.cpp">
       <Filter>Common Files</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\src\demos\app.h">
+    <ClInclude Include="..\..\src\demos\app.h">
       <Filter>Common Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\src\demos\timing.h">
+    <ClInclude Include="..\..\src\demos\timing.h">
       <Filter>Common Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/build/vs2010/demo_bigballistic_vc10.vcxproj
+++ b/build/vs2010/demo_bigballistic_vc10.vcxproj
@@ -38,11 +38,11 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.40219.1</_ProjectFileVersion>
-    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\bin\</OutDir>
-    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\tmp\bigballistic\Debug\</IntDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\..\bin\win32\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\..\tmp\bigballistic\Debug\</IntDir>
     <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</LinkIncremental>
-    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\bin\</OutDir>
-    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\tmp\bigballistic\</IntDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\..\bin\win32\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\..\tmp\bigballistic\</IntDir>
     <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</LinkIncremental>
     <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">AllRules.ruleset</CodeAnalysisRuleSet>
     <CodeAnalysisRules Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
@@ -56,7 +56,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -69,16 +69,16 @@
     <Link>
       <AdditionalDependencies>cyclone_d.lib;opengl32.lib;glu32.lib;glut32.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)$(TargetFileName)</OutputFile>
-      <AdditionalLibraryDirectories>../lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>../../lib/win32;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <ProgramDatabaseFile>..\tmp\bigballistic\Debug/bigballistic.pdb</ProgramDatabaseFile>
+      <ProgramDatabaseFile>..\..\tmp\bigballistic\Debug/bigballistic.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <AdditionalIncludeDirectories>..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <PrecompiledHeader>
@@ -89,7 +89,7 @@
     <Link>
       <AdditionalDependencies>cyclone.lib;opengl32.lib;glu32.lib;glut32.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)$(TargetFileName)</OutputFile>
-      <AdditionalLibraryDirectories>../lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>../../lib/win32;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
@@ -98,17 +98,17 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="..\src\demos\bigballistic\bigballistic.cpp" />
-    <ClCompile Include="..\src\demos\app.cpp" />
-    <ClCompile Include="..\src\demos\main.cpp">
+    <ClCompile Include="..\..\src\demos\bigballistic\bigballistic.cpp" />
+    <ClCompile Include="..\..\src\demos\app.cpp" />
+    <ClCompile Include="..\..\src\demos\main.cpp">
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)%(Filename)1.obj</ObjectFileName>
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)%(Filename)1.obj</ObjectFileName>
     </ClCompile>
-    <ClCompile Include="..\src\demos\timing.cpp" />
+    <ClCompile Include="..\..\src\demos\timing.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\src\demos\app.h" />
-    <ClInclude Include="..\src\demos\timing.h" />
+    <ClInclude Include="..\..\src\demos\app.h" />
+    <ClInclude Include="..\..\src\demos\timing.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/build/vs2010/demo_bigballistic_vc10.vcxproj.filters
+++ b/build/vs2010/demo_bigballistic_vc10.vcxproj.filters
@@ -18,24 +18,24 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\src\demos\bigballistic\bigballistic.cpp">
+    <ClCompile Include="..\..\src\demos\bigballistic\bigballistic.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\demos\app.cpp">
+    <ClCompile Include="..\..\src\demos\app.cpp">
       <Filter>Common Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\demos\main.cpp">
+    <ClCompile Include="..\..\src\demos\main.cpp">
       <Filter>Common Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\demos\timing.cpp">
+    <ClCompile Include="..\..\src\demos\timing.cpp">
       <Filter>Common Files</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\src\demos\app.h">
+    <ClInclude Include="..\..\src\demos\app.h">
       <Filter>Common Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\src\demos\timing.h">
+    <ClInclude Include="..\..\src\demos\timing.h">
       <Filter>Common Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/build/vs2010/demo_blob_vc10.vcxproj
+++ b/build/vs2010/demo_blob_vc10.vcxproj
@@ -38,11 +38,11 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.40219.1</_ProjectFileVersion>
-    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\bin\</OutDir>
-    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\tmp\blob\Debug\</IntDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\..\bin\win32\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\..\tmp\blob\Debug\</IntDir>
     <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</LinkIncremental>
-    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\bin\</OutDir>
-    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\tmp\blob\</IntDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\..\bin\win32\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\..\tmp\blob\</IntDir>
     <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</LinkIncremental>
     <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">AllRules.ruleset</CodeAnalysisRuleSet>
     <CodeAnalysisRules Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
@@ -56,7 +56,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -69,16 +69,16 @@
     <Link>
       <AdditionalDependencies>cyclone_d.lib;opengl32.lib;glu32.lib;glut32.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)$(TargetFileName)</OutputFile>
-      <AdditionalLibraryDirectories>../lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>../../lib/win32;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <ProgramDatabaseFile>..\tmp\blob\Debug/blob.pdb</ProgramDatabaseFile>
+      <ProgramDatabaseFile>..\..\tmp\blob\Debug/blob.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <AdditionalIncludeDirectories>..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <PrecompiledHeader>
@@ -89,7 +89,7 @@
     <Link>
       <AdditionalDependencies>cyclone.lib;opengl32.lib;glu32.lib;glut32.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)$(TargetFileName)</OutputFile>
-      <AdditionalLibraryDirectories>../lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>../../lib/win32;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
@@ -98,17 +98,17 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="..\src\demos\blob\blob.cpp" />
-    <ClCompile Include="..\src\demos\app.cpp" />
-    <ClCompile Include="..\src\demos\main.cpp">
+    <ClCompile Include="..\..\src\demos\blob\blob.cpp" />
+    <ClCompile Include="..\..\src\demos\app.cpp" />
+    <ClCompile Include="..\..\src\demos\main.cpp">
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)%(Filename)1.obj</ObjectFileName>
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)%(Filename)1.obj</ObjectFileName>
     </ClCompile>
-    <ClCompile Include="..\src\demos\timing.cpp" />
+    <ClCompile Include="..\..\src\demos\timing.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\src\demos\app.h" />
-    <ClInclude Include="..\src\demos\timing.h" />
+    <ClInclude Include="..\..\src\demos\app.h" />
+    <ClInclude Include="..\..\src\demos\timing.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/build/vs2010/demo_blob_vc10.vcxproj.filters
+++ b/build/vs2010/demo_blob_vc10.vcxproj.filters
@@ -18,24 +18,24 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\src\demos\blob\blob.cpp">
+    <ClCompile Include="..\..\src\demos\blob\blob.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\demos\app.cpp">
+    <ClCompile Include="..\..\src\demos\app.cpp">
       <Filter>Common Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\demos\main.cpp">
+    <ClCompile Include="..\..\src\demos\main.cpp">
       <Filter>Common Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\demos\timing.cpp">
+    <ClCompile Include="..\..\src\demos\timing.cpp">
       <Filter>Common Files</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\src\demos\app.h">
+    <ClInclude Include="..\..\src\demos\app.h">
       <Filter>Common Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\src\demos\timing.h">
+    <ClInclude Include="..\..\src\demos\timing.h">
       <Filter>Common Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/build/vs2010/demo_bridge_vc10.vcxproj
+++ b/build/vs2010/demo_bridge_vc10.vcxproj
@@ -38,11 +38,11 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.40219.1</_ProjectFileVersion>
-    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\bin\</OutDir>
-    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\tmp\bridge\Debug\</IntDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\..\bin\win32\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\..\tmp\bridge\Debug\</IntDir>
     <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</LinkIncremental>
-    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\bin\</OutDir>
-    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\tmp\bridge\</IntDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\..\bin\win32\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\..\tmp\bridge\</IntDir>
     <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</LinkIncremental>
     <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">AllRules.ruleset</CodeAnalysisRuleSet>
     <CodeAnalysisRules Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
@@ -56,7 +56,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -69,16 +69,16 @@
     <Link>
       <AdditionalDependencies>cyclone_d.lib;opengl32.lib;glu32.lib;glut32.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)$(TargetFileName)</OutputFile>
-      <AdditionalLibraryDirectories>../lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>../../lib/win32;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <ProgramDatabaseFile>..\tmp\bridge\Debug/bridge.pdb</ProgramDatabaseFile>
+      <ProgramDatabaseFile>..\..\tmp\bridge\Debug/bridge.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <AdditionalIncludeDirectories>..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <PrecompiledHeader>
@@ -89,7 +89,7 @@
     <Link>
       <AdditionalDependencies>cyclone.lib;opengl32.lib;glu32.lib;glut32.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)$(TargetFileName)</OutputFile>
-      <AdditionalLibraryDirectories>../lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>../../lib/win32;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
@@ -98,17 +98,17 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="..\src\demos\bridge\bridge.cpp" />
-    <ClCompile Include="..\src\demos\app.cpp" />
-    <ClCompile Include="..\src\demos\main.cpp">
+    <ClCompile Include="..\..\src\demos\bridge\bridge.cpp" />
+    <ClCompile Include="..\..\src\demos\app.cpp" />
+    <ClCompile Include="..\..\src\demos\main.cpp">
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)%(Filename)1.obj</ObjectFileName>
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)%(Filename)1.obj</ObjectFileName>
     </ClCompile>
-    <ClCompile Include="..\src\demos\timing.cpp" />
+    <ClCompile Include="..\..\src\demos\timing.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\src\demos\app.h" />
-    <ClInclude Include="..\src\demos\timing.h" />
+    <ClInclude Include="..\..\src\demos\app.h" />
+    <ClInclude Include="..\..\src\demos\timing.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/build/vs2010/demo_bridge_vc10.vcxproj.filters
+++ b/build/vs2010/demo_bridge_vc10.vcxproj.filters
@@ -18,24 +18,24 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\src\demos\bridge\bridge.cpp">
+    <ClCompile Include="..\..\src\demos\bridge\bridge.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\demos\app.cpp">
+    <ClCompile Include="..\..\src\demos\app.cpp">
       <Filter>Common Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\demos\main.cpp">
+    <ClCompile Include="..\..\src\demos\main.cpp">
       <Filter>Common Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\demos\timing.cpp">
+    <ClCompile Include="..\..\src\demos\timing.cpp">
       <Filter>Common Files</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\src\demos\app.h">
+    <ClInclude Include="..\..\src\demos\app.h">
       <Filter>Common Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\src\demos\timing.h">
+    <ClInclude Include="..\..\src\demos\timing.h">
       <Filter>Common Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/build/vs2010/demo_explosion_vc10.vcxproj
+++ b/build/vs2010/demo_explosion_vc10.vcxproj
@@ -38,11 +38,11 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.40219.1</_ProjectFileVersion>
-    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\bin\</OutDir>
-    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\tmp\explosion\Debug\</IntDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\..\bin\win32\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\..\tmp\explosion\Debug\</IntDir>
     <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</LinkIncremental>
-    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\bin\</OutDir>
-    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\tmp\explosion\</IntDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\..\bin\win32\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\..\tmp\explosion\</IntDir>
     <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</LinkIncremental>
     <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">AllRules.ruleset</CodeAnalysisRuleSet>
     <CodeAnalysisRules Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
@@ -56,7 +56,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -69,16 +69,16 @@
     <Link>
       <AdditionalDependencies>cyclone_d.lib;opengl32.lib;glu32.lib;glut32.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)$(TargetFileName)</OutputFile>
-      <AdditionalLibraryDirectories>../lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>../../lib/win32;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <ProgramDatabaseFile>..\tmp\explosion\Debug/explosion.pdb</ProgramDatabaseFile>
+      <ProgramDatabaseFile>..\..\tmp\explosion\Debug/explosion.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <AdditionalIncludeDirectories>..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <PrecompiledHeader>
@@ -89,7 +89,7 @@
     <Link>
       <AdditionalDependencies>cyclone.lib;opengl32.lib;glu32.lib;glut32.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)$(TargetFileName)</OutputFile>
-      <AdditionalLibraryDirectories>../lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>../../lib/win32;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
@@ -98,17 +98,17 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="..\src\demos\explosion\explosion.cpp" />
-    <ClCompile Include="..\src\demos\app.cpp" />
-    <ClCompile Include="..\src\demos\main.cpp">
+    <ClCompile Include="..\..\src\demos\explosion\explosion.cpp" />
+    <ClCompile Include="..\..\src\demos\app.cpp" />
+    <ClCompile Include="..\..\src\demos\main.cpp">
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)%(Filename)1.obj</ObjectFileName>
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)%(Filename)1.obj</ObjectFileName>
     </ClCompile>
-    <ClCompile Include="..\src\demos\timing.cpp" />
+    <ClCompile Include="..\..\src\demos\timing.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\src\demos\app.h" />
-    <ClInclude Include="..\src\demos\timing.h" />
+    <ClInclude Include="..\..\src\demos\app.h" />
+    <ClInclude Include="..\..\src\demos\timing.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/build/vs2010/demo_explosion_vc10.vcxproj.filters
+++ b/build/vs2010/demo_explosion_vc10.vcxproj.filters
@@ -18,24 +18,24 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\src\demos\explosion\explosion.cpp">
+    <ClCompile Include="..\..\src\demos\explosion\explosion.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\demos\app.cpp">
+    <ClCompile Include="..\..\src\demos\app.cpp">
       <Filter>Common Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\demos\main.cpp">
+    <ClCompile Include="..\..\src\demos\main.cpp">
       <Filter>Common Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\demos\timing.cpp">
+    <ClCompile Include="..\..\src\demos\timing.cpp">
       <Filter>Common Files</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\src\demos\app.h">
+    <ClInclude Include="..\..\src\demos\app.h">
       <Filter>Common Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\src\demos\timing.h">
+    <ClInclude Include="..\..\src\demos\timing.h">
       <Filter>Common Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/build/vs2010/demo_fireworks_vc10.vcxproj
+++ b/build/vs2010/demo_fireworks_vc10.vcxproj
@@ -38,11 +38,11 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.40219.1</_ProjectFileVersion>
-    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\bin\</OutDir>
-    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\tmp\fireworks\Debug\</IntDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\..\bin\win32\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\..\tmp\fireworks\Debug\</IntDir>
     <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</LinkIncremental>
-    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\bin\</OutDir>
-    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\tmp\fireworks\</IntDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\..\bin\win32\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\..\tmp\fireworks\</IntDir>
     <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</LinkIncremental>
     <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">AllRules.ruleset</CodeAnalysisRuleSet>
     <CodeAnalysisRules Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
@@ -56,7 +56,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -69,16 +69,16 @@
     <Link>
       <AdditionalDependencies>cyclone_d.lib;opengl32.lib;glu32.lib;glut32.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)$(TargetFileName)</OutputFile>
-      <AdditionalLibraryDirectories>../lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>../../lib/win32;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <ProgramDatabaseFile>..\tmp\fireworks\Debug/fireworks.pdb</ProgramDatabaseFile>
+      <ProgramDatabaseFile>..\..\tmp\fireworks\Debug/fireworks.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <AdditionalIncludeDirectories>..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <PrecompiledHeader>
@@ -89,7 +89,7 @@
     <Link>
       <AdditionalDependencies>cyclone.lib;opengl32.lib;glu32.lib;glut32.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)$(TargetFileName)</OutputFile>
-      <AdditionalLibraryDirectories>../lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>../../lib/win32;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
@@ -98,17 +98,17 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="..\src\demos\fireworks\fireworks.cpp" />
-    <ClCompile Include="..\src\demos\app.cpp" />
-    <ClCompile Include="..\src\demos\main.cpp">
+    <ClCompile Include="..\..\src\demos\fireworks\fireworks.cpp" />
+    <ClCompile Include="..\..\src\demos\app.cpp" />
+    <ClCompile Include="..\..\src\demos\main.cpp">
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)%(Filename)1.obj</ObjectFileName>
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)%(Filename)1.obj</ObjectFileName>
     </ClCompile>
-    <ClCompile Include="..\src\demos\timing.cpp" />
+    <ClCompile Include="..\..\src\demos\timing.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\src\demos\app.h" />
-    <ClInclude Include="..\src\demos\timing.h" />
+    <ClInclude Include="..\..\src\demos\app.h" />
+    <ClInclude Include="..\..\src\demos\timing.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/build/vs2010/demo_fireworks_vc10.vcxproj.filters
+++ b/build/vs2010/demo_fireworks_vc10.vcxproj.filters
@@ -18,24 +18,24 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\src\demos\fireworks\fireworks.cpp">
+    <ClCompile Include="..\..\src\demos\fireworks\fireworks.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\demos\app.cpp">
+    <ClCompile Include="..\..\src\demos\app.cpp">
       <Filter>Common Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\demos\main.cpp">
+    <ClCompile Include="..\..\src\demos\main.cpp">
       <Filter>Common Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\demos\timing.cpp">
+    <ClCompile Include="..\..\src\demos\timing.cpp">
       <Filter>Common Files</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\src\demos\app.h">
+    <ClInclude Include="..\..\src\demos\app.h">
       <Filter>Common Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\src\demos\timing.h">
+    <ClInclude Include="..\..\src\demos\timing.h">
       <Filter>Common Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/build/vs2010/demo_flightsim_vc10.vcxproj
+++ b/build/vs2010/demo_flightsim_vc10.vcxproj
@@ -38,11 +38,11 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.40219.1</_ProjectFileVersion>
-    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\bin\</OutDir>
-    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\tmp\flightsim\Debug\</IntDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\..\bin\win32\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\..\tmp\flightsim\Debug\</IntDir>
     <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</LinkIncremental>
-    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\bin\</OutDir>
-    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\tmp\flightsim\</IntDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\..\bin\win32\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\..\tmp\flightsim\</IntDir>
     <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</LinkIncremental>
     <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">AllRules.ruleset</CodeAnalysisRuleSet>
     <CodeAnalysisRules Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
@@ -56,7 +56,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -69,16 +69,16 @@
     <Link>
       <AdditionalDependencies>cyclone_d.lib;opengl32.lib;glu32.lib;glut32.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)$(TargetFileName)</OutputFile>
-      <AdditionalLibraryDirectories>../lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>../../lib/win32;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <ProgramDatabaseFile>..\tmp\flightsim\Debug/flightsim.pdb</ProgramDatabaseFile>
+      <ProgramDatabaseFile>..\..\tmp\flightsim\Debug/flightsim.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <AdditionalIncludeDirectories>..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <PrecompiledHeader>
@@ -89,7 +89,7 @@
     <Link>
       <AdditionalDependencies>cyclone.lib;opengl32.lib;glu32.lib;glut32.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)$(TargetFileName)</OutputFile>
-      <AdditionalLibraryDirectories>../lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>../../lib/win32;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
@@ -98,17 +98,17 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="..\src\demos\flightsim\flightsim.cpp" />
-    <ClCompile Include="..\src\demos\app.cpp" />
-    <ClCompile Include="..\src\demos\main.cpp">
+    <ClCompile Include="..\..\src\demos\flightsim\flightsim.cpp" />
+    <ClCompile Include="..\..\src\demos\app.cpp" />
+    <ClCompile Include="..\..\src\demos\main.cpp">
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)%(Filename)1.obj</ObjectFileName>
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)%(Filename)1.obj</ObjectFileName>
     </ClCompile>
-    <ClCompile Include="..\src\demos\timing.cpp" />
+    <ClCompile Include="..\..\src\demos\timing.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\src\demos\app.h" />
-    <ClInclude Include="..\src\demos\timing.h" />
+    <ClInclude Include="..\..\src\demos\app.h" />
+    <ClInclude Include="..\..\src\demos\timing.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/build/vs2010/demo_flightsim_vc10.vcxproj.filters
+++ b/build/vs2010/demo_flightsim_vc10.vcxproj.filters
@@ -18,24 +18,24 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\src\demos\flightsim\flightsim.cpp">
+    <ClCompile Include="..\..\src\demos\flightsim\flightsim.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\demos\app.cpp">
+    <ClCompile Include="..\..\src\demos\app.cpp">
       <Filter>Common Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\demos\main.cpp">
+    <ClCompile Include="..\..\src\demos\main.cpp">
       <Filter>Common Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\demos\timing.cpp">
+    <ClCompile Include="..\..\src\demos\timing.cpp">
       <Filter>Common Files</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\src\demos\app.h">
+    <ClInclude Include="..\..\src\demos\app.h">
       <Filter>Common Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\src\demos\timing.h">
+    <ClInclude Include="..\..\src\demos\timing.h">
       <Filter>Common Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/build/vs2010/demo_fracture_vc10.vcxproj
+++ b/build/vs2010/demo_fracture_vc10.vcxproj
@@ -38,11 +38,11 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.40219.1</_ProjectFileVersion>
-    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\bin\</OutDir>
-    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\tmp\fracture\Debug\</IntDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\..\bin\win32\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\..\tmp\fracture\Debug\</IntDir>
     <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</LinkIncremental>
-    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\bin\</OutDir>
-    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\tmp\fracture\</IntDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\..\bin\win32\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\..\tmp\fracture\</IntDir>
     <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</LinkIncremental>
     <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">AllRules.ruleset</CodeAnalysisRuleSet>
     <CodeAnalysisRules Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
@@ -56,7 +56,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -69,16 +69,16 @@
     <Link>
       <AdditionalDependencies>cyclone_d.lib;opengl32.lib;glu32.lib;glut32.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)$(TargetFileName)</OutputFile>
-      <AdditionalLibraryDirectories>../lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>../../lib/win32;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <ProgramDatabaseFile>..\tmp\fracture\Debug/fracture.pdb</ProgramDatabaseFile>
+      <ProgramDatabaseFile>..\..\tmp\fracture\Debug/fracture.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <AdditionalIncludeDirectories>..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <PrecompiledHeader>
@@ -89,7 +89,7 @@
     <Link>
       <AdditionalDependencies>cyclone.lib;opengl32.lib;glu32.lib;glut32.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)$(TargetFileName)</OutputFile>
-      <AdditionalLibraryDirectories>../lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>../../lib/win32;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
@@ -98,17 +98,17 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="..\src\demos\fracture\fracture.cpp" />
-    <ClCompile Include="..\src\demos\app.cpp" />
-    <ClCompile Include="..\src\demos\main.cpp">
+    <ClCompile Include="..\..\src\demos\fracture\fracture.cpp" />
+    <ClCompile Include="..\..\src\demos\app.cpp" />
+    <ClCompile Include="..\..\src\demos\main.cpp">
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)%(Filename)1.obj</ObjectFileName>
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)%(Filename)1.obj</ObjectFileName>
     </ClCompile>
-    <ClCompile Include="..\src\demos\timing.cpp" />
+    <ClCompile Include="..\..\src\demos\timing.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\src\demos\app.h" />
-    <ClInclude Include="..\src\demos\timing.h" />
+    <ClInclude Include="..\..\src\demos\app.h" />
+    <ClInclude Include="..\..\src\demos\timing.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/build/vs2010/demo_fracture_vc10.vcxproj.filters
+++ b/build/vs2010/demo_fracture_vc10.vcxproj.filters
@@ -18,24 +18,24 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\src\demos\fracture\fracture.cpp">
+    <ClCompile Include="..\..\src\demos\fracture\fracture.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\demos\app.cpp">
+    <ClCompile Include="..\..\src\demos\app.cpp">
       <Filter>Common Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\demos\main.cpp">
+    <ClCompile Include="..\..\src\demos\main.cpp">
       <Filter>Common Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\demos\timing.cpp">
+    <ClCompile Include="..\..\src\demos\timing.cpp">
       <Filter>Common Files</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\src\demos\app.h">
+    <ClInclude Include="..\..\src\demos\app.h">
       <Filter>Common Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\src\demos\timing.h">
+    <ClInclude Include="..\..\src\demos\timing.h">
       <Filter>Common Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/build/vs2010/demo_platform_vc10.vcxproj
+++ b/build/vs2010/demo_platform_vc10.vcxproj
@@ -38,11 +38,11 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.40219.1</_ProjectFileVersion>
-    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\bin\</OutDir>
-    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\tmp\platform\Debug\</IntDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\..\bin\win32\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\..\tmp\platform\Debug\</IntDir>
     <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</LinkIncremental>
-    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\bin\</OutDir>
-    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\tmp\platform\</IntDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\..\bin\win32\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\..\tmp\platform\</IntDir>
     <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</LinkIncremental>
     <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">AllRules.ruleset</CodeAnalysisRuleSet>
     <CodeAnalysisRules Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
@@ -56,7 +56,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -69,16 +69,16 @@
     <Link>
       <AdditionalDependencies>cyclone_d.lib;opengl32.lib;glu32.lib;glut32.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)$(TargetFileName)</OutputFile>
-      <AdditionalLibraryDirectories>../lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>../../lib/win32;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <ProgramDatabaseFile>..\tmp\platform\Debug/platform.pdb</ProgramDatabaseFile>
+      <ProgramDatabaseFile>..\..\tmp\platform\Debug/platform.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <AdditionalIncludeDirectories>..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <PrecompiledHeader>
@@ -89,7 +89,7 @@
     <Link>
       <AdditionalDependencies>cyclone.lib;opengl32.lib;glu32.lib;glut32.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)$(TargetFileName)</OutputFile>
-      <AdditionalLibraryDirectories>../lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>../../lib/win32;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
@@ -98,17 +98,17 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="..\src\demos\platform\platform.cpp" />
-    <ClCompile Include="..\src\demos\app.cpp" />
-    <ClCompile Include="..\src\demos\main.cpp">
+    <ClCompile Include="..\..\src\demos\platform\platform.cpp" />
+    <ClCompile Include="..\..\src\demos\app.cpp" />
+    <ClCompile Include="..\..\src\demos\main.cpp">
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)%(Filename)1.obj</ObjectFileName>
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)%(Filename)1.obj</ObjectFileName>
     </ClCompile>
-    <ClCompile Include="..\src\demos\timing.cpp" />
+    <ClCompile Include="..\..\src\demos\timing.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\src\demos\app.h" />
-    <ClInclude Include="..\src\demos\timing.h" />
+    <ClInclude Include="..\..\src\demos\app.h" />
+    <ClInclude Include="..\..\src\demos\timing.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/build/vs2010/demo_platform_vc10.vcxproj.filters
+++ b/build/vs2010/demo_platform_vc10.vcxproj.filters
@@ -18,24 +18,24 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\src\demos\platform\platform.cpp">
+    <ClCompile Include="..\..\src\demos\platform\platform.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\demos\app.cpp">
+    <ClCompile Include="..\..\src\demos\app.cpp">
       <Filter>Common Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\demos\main.cpp">
+    <ClCompile Include="..\..\src\demos\main.cpp">
       <Filter>Common Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\demos\timing.cpp">
+    <ClCompile Include="..\..\src\demos\timing.cpp">
       <Filter>Common Files</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\src\demos\app.h">
+    <ClInclude Include="..\..\src\demos\app.h">
       <Filter>Common Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\src\demos\timing.h">
+    <ClInclude Include="..\..\src\demos\timing.h">
       <Filter>Common Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/build/vs2010/demo_ragdoll_vc10.vcxproj
+++ b/build/vs2010/demo_ragdoll_vc10.vcxproj
@@ -38,11 +38,11 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.40219.1</_ProjectFileVersion>
-    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\bin\</OutDir>
-    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\tmp\ragdoll\Debug\</IntDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\..\bin\win32\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\..\tmp\ragdoll\Debug\</IntDir>
     <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</LinkIncremental>
-    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\bin\</OutDir>
-    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\tmp\ragdoll\</IntDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\..\bin\win32\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\..\tmp\ragdoll\</IntDir>
     <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</LinkIncremental>
     <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">AllRules.ruleset</CodeAnalysisRuleSet>
     <CodeAnalysisRules Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
@@ -56,7 +56,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -69,16 +69,16 @@
     <Link>
       <AdditionalDependencies>cyclone_d.lib;opengl32.lib;glu32.lib;glut32.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)$(TargetFileName)</OutputFile>
-      <AdditionalLibraryDirectories>../lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>../../lib/win32;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <ProgramDatabaseFile>..\tmp\ragdoll\Debug/ragdoll.pdb</ProgramDatabaseFile>
+      <ProgramDatabaseFile>..\..\tmp\ragdoll\Debug/ragdoll.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <AdditionalIncludeDirectories>..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <PrecompiledHeader>
@@ -89,7 +89,7 @@
     <Link>
       <AdditionalDependencies>cyclone.lib;opengl32.lib;glu32.lib;glut32.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)$(TargetFileName)</OutputFile>
-      <AdditionalLibraryDirectories>../lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>../../lib/win32;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
@@ -98,17 +98,17 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="..\src\demos\ragdoll\ragdoll.cpp" />
-    <ClCompile Include="..\src\demos\app.cpp" />
-    <ClCompile Include="..\src\demos\main.cpp">
+    <ClCompile Include="..\..\src\demos\ragdoll\ragdoll.cpp" />
+    <ClCompile Include="..\..\src\demos\app.cpp" />
+    <ClCompile Include="..\..\src\demos\main.cpp">
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)%(Filename)1.obj</ObjectFileName>
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)%(Filename)1.obj</ObjectFileName>
     </ClCompile>
-    <ClCompile Include="..\src\demos\timing.cpp" />
+    <ClCompile Include="..\..\src\demos\timing.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\src\demos\app.h" />
-    <ClInclude Include="..\src\demos\timing.h" />
+    <ClInclude Include="..\..\src\demos\app.h" />
+    <ClInclude Include="..\..\src\demos\timing.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/build/vs2010/demo_ragdoll_vc10.vcxproj.filters
+++ b/build/vs2010/demo_ragdoll_vc10.vcxproj.filters
@@ -18,24 +18,24 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\src\demos\ragdoll\ragdoll.cpp">
+    <ClCompile Include="..\..\src\demos\ragdoll\ragdoll.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\demos\app.cpp">
+    <ClCompile Include="..\..\src\demos\app.cpp">
       <Filter>Common Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\demos\main.cpp">
+    <ClCompile Include="..\..\src\demos\main.cpp">
       <Filter>Common Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\demos\timing.cpp">
+    <ClCompile Include="..\..\src\demos\timing.cpp">
       <Filter>Common Files</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\src\demos\app.h">
+    <ClInclude Include="..\..\src\demos\app.h">
       <Filter>Common Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\src\demos\timing.h">
+    <ClInclude Include="..\..\src\demos\timing.h">
       <Filter>Common Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/build/vs2010/demo_sailboat_vc10.vcxproj
+++ b/build/vs2010/demo_sailboat_vc10.vcxproj
@@ -38,11 +38,11 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.40219.1</_ProjectFileVersion>
-    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\bin\</OutDir>
-    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\tmp\sailboat\Debug\</IntDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\..\bin\win32\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\..\tmp\sailboat\Debug\</IntDir>
     <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</LinkIncremental>
-    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\bin\</OutDir>
-    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\tmp\sailboat\</IntDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\..\bin\win32\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\..\tmp\sailboat\</IntDir>
     <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</LinkIncremental>
     <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">AllRules.ruleset</CodeAnalysisRuleSet>
     <CodeAnalysisRules Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
@@ -56,7 +56,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -69,16 +69,16 @@
     <Link>
       <AdditionalDependencies>cyclone_d.lib;opengl32.lib;glu32.lib;glut32.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)$(TargetFileName)</OutputFile>
-      <AdditionalLibraryDirectories>../lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>../../lib/win32;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <ProgramDatabaseFile>..\tmp\sailboat\Debug/sailboat.pdb</ProgramDatabaseFile>
+      <ProgramDatabaseFile>..\..\tmp\sailboat\Debug/sailboat.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <AdditionalIncludeDirectories>..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <PrecompiledHeader>
@@ -89,7 +89,7 @@
     <Link>
       <AdditionalDependencies>cyclone.lib;opengl32.lib;glu32.lib;glut32.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)$(TargetFileName)</OutputFile>
-      <AdditionalLibraryDirectories>../lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>../../lib/win32;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
@@ -98,17 +98,17 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="..\src\demos\sailboat\sailboat.cpp" />
-    <ClCompile Include="..\src\demos\app.cpp" />
-    <ClCompile Include="..\src\demos\main.cpp">
+    <ClCompile Include="..\..\src\demos\sailboat\sailboat.cpp" />
+    <ClCompile Include="..\..\src\demos\app.cpp" />
+    <ClCompile Include="..\..\src\demos\main.cpp">
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)%(Filename)1.obj</ObjectFileName>
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)%(Filename)1.obj</ObjectFileName>
     </ClCompile>
-    <ClCompile Include="..\src\demos\timing.cpp" />
+    <ClCompile Include="..\..\src\demos\timing.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\src\demos\app.h" />
-    <ClInclude Include="..\src\demos\timing.h" />
+    <ClInclude Include="..\..\src\demos\app.h" />
+    <ClInclude Include="..\..\src\demos\timing.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/build/vs2010/demo_sailboat_vc10.vcxproj.filters
+++ b/build/vs2010/demo_sailboat_vc10.vcxproj.filters
@@ -18,24 +18,24 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\src\demos\sailboat\sailboat.cpp">
+    <ClCompile Include="..\..\src\demos\sailboat\sailboat.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\demos\app.cpp">
+    <ClCompile Include="..\..\src\demos\app.cpp">
       <Filter>Common Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\demos\main.cpp">
+    <ClCompile Include="..\..\src\demos\main.cpp">
       <Filter>Common Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\demos\timing.cpp">
+    <ClCompile Include="..\..\src\demos\timing.cpp">
       <Filter>Common Files</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\src\demos\app.h">
+    <ClInclude Include="..\..\src\demos\app.h">
       <Filter>Common Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\src\demos\timing.h">
+    <ClInclude Include="..\..\src\demos\timing.h">
       <Filter>Common Files</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
Relative path were broken after change to build folder. This commit fixes relative paths from VS2012 projects