### PR TITLE
Fix getDeterminant call in Matrix4::setInverse

### DIFF
--- a/src/core.cpp
+++ b/src/core.cpp
@@ -54,7 +54,7 @@ real Matrix4::getDeterminant() const
 void Matrix4::setInverse(const Matrix4 &m)
 {
     // Make sure the determinant is non-zero.
-    real det = getDeterminant();
+    real det = m.getDeterminant();
     if (det == 0) return;
     det = ((real)1.0)/det;
 


### PR DESCRIPTION
This is the solution to the issue I told you in the issues section about getDeterminant